### PR TITLE
Updated item class

### DIFF
--- a/item.rb
+++ b/item.rb
@@ -1,31 +1,37 @@
+require 'securerandom'
 require 'date'
 
 class Item
-  attr_accessor :publish_date, :author, :source, :genre, :label, :id
-  attr_reader :archived
+  attr_accessor :publish_date, :archived
+  attr_reader :id
 
-  def initialize(publish_date)
-    @id = Random.rand(1..1000)
-    @publish_date = Date.parse(publish_date)
-    @archived = false
-    # 1-to-many relationships
-    @author = 'unknown'
-    @source = 'unknown'
-    @label = 'unknown'
-    @genre = 'unknown'
-  end
-
-  def add_author(author)
-    @author = author
-    author.add_item(self) unless author.items.include?(self)
-  end
-
-  def can_be_archived?
-    ten_years_ago = time.now.year - @publish_date.year
-    ten_years_ago > 10
+  def initialize(publish_date, archived: false)
+    @id = SecureRandom.hex(5)
+    @publish_date = publish_date
+    @archived = archived
   end
 
   def move_to_archive
-    @archived = true if can_be_archived?
+    self.archived = true if can_be_archived?
+    self.archived = false unless can_be_archived?
+  end
+
+  def author=(author)
+    @author = author
+    author.items << self
+  end
+
+  def genre=(genre)
+    @genre = genre
+    genre.items << self
+  end
+
+  def label=(label)
+    @label = label
+    @label.items << self
+  end
+
+  def can_be_archived?
+    Date.strptime(@publish_date, '%Y-%m-%d') < DateTime.now.prev_year(10)
   end
 end


### PR DESCRIPTION
All Item class properties visible in the diagram should be defined and set up in the constructor method. Exception: properties for the 1-to-many relationships should NOT be set in the constructor method. Instead, they should have a custom setter method created.

Add all methods visible in the diagram.
Implement methods:

- can_be_archived?() in the Item class
- should return true if published_date is older than 10 years
- otherwise, it should return false
- move_to_archive() in the Item class
- should reuse can_be_archived?() method
- should change the archived property to true if the result of the can_be_archived?() method is true
- should do nothing if the result of the can_be_archived?() method is false
#4 